### PR TITLE
feat: move default channel

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -82,7 +82,10 @@
       "retention": "INTEGER",
       "owner_org": "TEXT",
       "default_upload_channel": "TEXT",
-      "transfer_history": "JSON"
+      "transfer_history": "JSON",
+      "default_channel_ios": "INTEGER",
+      "default_channel_android": "INTEGER",
+      "default_channel_sync": "BOOLEAN"
     },
     "indexes": [
       "app_id",

--- a/wrangler.json
+++ b/wrangler.json
@@ -22,5 +22,8 @@
       "database_name": "capgo_prod_replicate",
       "database_id": "7f267d86-f4f7-49f5-9622-e44373aa00dc"
     }
-  ]
+  ],
+  "vars": {
+    "WEBHOOK_SECRET": "your_strong_webhook_secret"
+  }
 } 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new columns to the apps table for iOS and Android default channels and sync status.
  - Introduced a new environment variable for webhook secret configuration.

- **Documentation**
  - Updated README with instructions and a SQL snippet for replicating existing tables into the queue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->